### PR TITLE
template.svg: Remove redundant space

### DIFF
--- a/template.svg
+++ b/template.svg
@@ -18,7 +18,7 @@
   <rect rx="4" x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="18" fill="{{=it.colorB||"#4c1"}}"/>
   <rect x="{{=it.widths[0]}}" width="4" height="18" fill="{{=it.colorB||"#4c1"}}"/>
   <rect rx="4" width="{{=it.widths[0]+it.widths[1]}}" height="18" fill="url(#smooth)"/>
-  <g fill="#fff" text-anchor="middle" font-family="Verdana, sans-serif" font-size="10">
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,sans-serif" font-size="10">
     <text x="{{=it.widths[0]/2+1}}" y="12" filter="url(#shadow)">{{=it.text[0]}}</text>
     <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="12" filter="url(#shadow)">{{=it.text[1]}}</text>
   </g>


### PR DESCRIPTION
SVGO doesn’t remove it, so let’s do it manually.
