### PR TITLE
Added support for specific Travis CI branches.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all:
 deploy:
 	git add Verdana.ttf
 	git commit -m'MUST NOT BE ON GITHUB'
-	git push -f heroku master
+	git push -f heroku HEAD:master
 	git reset HEAD~1
 
 .PHONY: all deploy

--- a/web/index.html
+++ b/web/index.html
@@ -86,9 +86,13 @@ Use an underscore <code>_</code> if you want a space. Or, you know, use a space.
 <h2> Supported Services </h2>
 
 <table><tbody>
-  <tr><th> Travis: </th>
+  <tr><th> Travis (repo): </th>
   <td><img src='/travis/joyent/node.svg' alt='Travis-CI'/></td>
   <td><code>http://b.adge.me/travis/joyent/node.svg</code></td>
+  </tr>
+  <tr><th> Travis (branch): </th>
+  <td><img src='/travis/joyent/node/v0.6.svg' alt='Travis-CI'/></td>
+  <td><code>http://b.adge.me/travis/joyent/node/v0.6.svg</code></td>
   </tr>
   <tr><th> Gittip: </th>
   <td><img src='/gittip/JSFiddle.svg' alt='Gittip'/></td>


### PR DESCRIPTION
As discussed in #24.

Demo URL: http://salty-beyond-1018.herokuapp.com/

I ended up having to request the existing Travis status images and parse the headers to work out the status, much like the existing Coveralls implementation. There were two main reasons for this:
- I couldn't figure out how to how to get the build status for the last **completed** build for a given branch via the API, which is how the built-in Travis images behave - even the Travis CLI tool doesn't do this.
- The Travis API for getting the most recent build does not currently support branch names that contain a slash, which is quite common (see travis-ci/travis-ci#1614).

I also made a small update to the deploy target to allow deploying from any branch, let me know if that's not cool :)
