### PR TITLE
Allow custom labels for integrated services.

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,7 +21,8 @@ function(data, match, end, ask) {
   if (branch) {
     options.path += '?branch=' + branch;
   }
-  var badgeData = {text:['build', 'n/a'], colorscheme:'lightgrey'};
+  var label = getLabel('build', data);
+  var badgeData = {text:[label, 'n/a'], colorscheme:'lightgrey'};
   var req = https.request(options, function(res) {
     try {
       var statusMatch = res.headers['content-disposition']
@@ -58,7 +59,8 @@ function(data, match, end, ask) {
   var user = match[1];  // eg, `JSFiddle`.
   var format = match[2];
   var apiUrl = 'https://www.gittip.com/' + user + '/public.json';
-  var badgeData = {text:['tips', 'n/a'], colorscheme:'lightgrey'};
+  var label = getLabel('tips', data);
+  var badgeData = {text:[label, 'n/a'], colorscheme:'lightgrey'};
   https.get(apiUrl, function(res) {
     var buffer = '';
     res.on('data', function(chunk) { buffer += ''+chunk; });
@@ -96,7 +98,8 @@ function(data, match, end, ask) {
   var userRepo = match[1];  // eg, `doctrine/orm`.
   var format = match[2];
   var apiUrl = 'https://packagist.org/packages/' + userRepo + '.json';
-  var badgeData = {text:['downloads', 'n/a'], colorscheme:'lightgrey'};
+  var label = getLabel('downloads', data);
+  var badgeData = {text:[label, 'n/a'], colorscheme:'lightgrey'};
   https.get(apiUrl, function(res) {
     var buffer = '';
     res.on('data', function(chunk) { buffer += ''+chunk; });
@@ -134,7 +137,8 @@ function(data, match, end, ask) {
   var user = match[1];  // eg, `localeval`.
   var format = match[2];
   var apiUrl = 'http://isaacs.iriscouch.com/downloads/_design/app/_view/pkg?group_level=2&start_key=["' + user + '"]&end_key=["' + user + '",{}]';
-  var badgeData = {text:['downloads', 'n/a'], colorscheme:'lightgrey'};
+  var label = getLabel('downloads', data);
+  var badgeData = {text:[label, 'n/a'], colorscheme:'lightgrey'};
   http.get(apiUrl, function(res) {
     var buffer = '';
     res.on('data', function(chunk) { buffer += ''+chunk; });
@@ -184,7 +188,8 @@ function(data, match, end, ask) {
   var repo = match[1];  // eg, `localeval`.
   var format = match[2];
   var apiUrl = 'https://registry.npmjs.org/' + repo + '/latest';
-  var badgeData = {text:['npm', 'n/a'], colorscheme:'lightgrey'};
+  var label = getLabel('npm', data);
+  var badgeData = {text:[label, 'n/a'], colorscheme:'lightgrey'};
   https.get(apiUrl, function(res) {
     var buffer = '';
     res.on('data', function(chunk) { buffer += ''+chunk; });
@@ -218,7 +223,8 @@ function(data, match, end, ask) {
   var repo = match[1];  // eg, `localeval`.
   var format = match[2];
   var apiUrl = 'https://rubygems.org/api/v1/gems/' + repo + '.json';
-  var badgeData = {text:['gem', 'n/a'], colorscheme:'lightgrey'};
+  var label = getLabel('gem', data);
+  var badgeData = {text:[label, 'n/a'], colorscheme:'lightgrey'};
   https.get(apiUrl, function(res) {
     var buffer = '';
     res.on('data', function(chunk) { buffer += ''+chunk; });
@@ -256,7 +262,8 @@ function(data, match, end, ask) {
   if (branch) {
     apiUrl += '?branch=' + branch;
   }
-  var badgeData = {text:['coverage', 'n/a'], colorscheme:'lightgrey'};
+  var label = getLabel('coverage', data);
+  var badgeData = {text:[label, 'n/a'], colorscheme:'lightgrey'};
   https.get(apiUrl, function(res) {
     // We should get a 302. Look inside the Location header.
     var buffer = res.headers.location;
@@ -304,7 +311,8 @@ function(data, match, end, ask) {
     hostname: 'codeclimate.com',
     path: '/' + userRepo + '.png'
   };
-  var badgeData = {text:['code climate', 'n/a'], colorscheme:'lightgrey'};
+  var label = getLabel('code climate', data);
+  var badgeData = {text:[label, 'n/a'], colorscheme:'lightgrey'};
   var req = https.request(options, function(res) {
     try {
       var statusMatch = res.headers['content-disposition']
@@ -352,7 +360,8 @@ function(data, match, end, ask) {
     hostname: 'gemnasium.com',
     path: '/' + userRepo + '.png'
   };
-  var badgeData = {text:['dependencies', 'n/a'], colorscheme:'lightgrey'};
+  var label = getLabel('dependencies', data);
+  var badgeData = {text:[label, 'n/a'], colorscheme:'lightgrey'};
   var req = https.request(options, function(res) {
     try {
       var statusMatch = res.headers['content-disposition']
@@ -469,6 +478,13 @@ function escapeFormat(t) {
 }
 
 function sixHex(s) { return /^[0-9a-fA-F]{6}$/.test(s); }
+
+function getLabel(label, data) {
+  if (data.label) {
+    return escapeFormat(data.label);
+  }
+  return label;
+}
 
 function makeSend(format, askres, end) {
   if (format === 'svg') {


### PR DESCRIPTION
This PR allows for customizable labels on any badge that is driven by a third-party service. Some example usages for this include:
- When displaying build results for multiple branches, 'build' can be replaced with 'develop' or 'master', or some other value, in order to differentiate the two results.
- Similar idea for branch test coverage.
- When a project exists on both NPM and Packagist (for example, Twitter Bootstrap), 'downloads' can be replaced with the name of the repository to differentiate the two.

Custom labels can be added to any of these services by simply adding a 'label' query parameter (e.g. ?label=foo). The value of the label parameter follows the same escaping rules as other custom text.

Example images from a Heroku instance running this PR:

![Node 0.6 Travis status](http://serene-ocean-2167.herokuapp.com/travis/joyent/node/v0.6.svg?label=0.6)
![Jekyll master Coveralls status](http://serene-ocean-2167.herokuapp.com/coveralls/jekyll/jekyll/master.svg?label=master_coverage)
![Localeval NPM downloads](http://serene-ocean-2167.herokuapp.com/npm/dm/localeval.svg?label=npm)
![Doctrine ORM Packagist downloads](http://serene-ocean-2167.herokuapp.com/packagist/dm/doctrine/orm.svg?label=packagist)
