### PR TITLE
Added no-cache headers - fixes #28

### DIFF
--- a/server.js
+++ b/server.js
@@ -517,9 +517,6 @@ function(data, match, end, ask) {
   var color = escapeFormat(match[6]);
   var format = match[8];
 
-  // Cache management.
-  var cacheDuration = (3600*24*1)|0;  // 1 day.
-  ask.res.setHeader('Cache-Control', 'public, max-age=' + cacheDuration);
   if (+(new Date(ask.req.headers['if-modified-since'])) >= +serverStartTime) {
     ask.res.statusCode = 304;
     ask.res.end();  // not modified.
@@ -549,9 +546,6 @@ function(data, match, end, ask) {
   var status = match[2];
   var color = data.color;
 
-  // Cache management.
-  var cacheDuration = (3600*24*1)|0;  // 1 day.
-  ask.res.setHeader('Cache-Control', 'public, max-age=' + cacheDuration);
   if (+(new Date(ask.req.headers['if-modified-since'])) >= +serverStartTime) {
     ask.res.statusCode = 304;
     ask.res.end();  // not modified.
@@ -589,6 +583,9 @@ function getLabel(label, data) {
 }
 
 function makeSend(format, askres, end) {
+  // Cache management - no cache, so it won't be cached by Github's CDN.
+  askres.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+
   if (format === 'svg') {
     return function(res) { sendSVG(res, askres, end); };
   } else {


### PR DESCRIPTION
To let the badges stay update to date, `no-cache` headers should be set, so that Github doesn't cache them in their CDN.
